### PR TITLE
Corrección @Past y nota con validación en UML OK!

### DIFF
--- a/reports/model.uxf
+++ b/reports/model.uxf
@@ -233,7 +233,7 @@ CodeAudit
 + type: Type
 + correctiveActions: String {NotBlank,Length(max=100)}
 + mark: Mark
-+link: String {URL}
++ link: String {URL}
 bg=pink</panel_attributes>
     <additional_attributes/>
   </element>
@@ -284,5 +284,24 @@ createdBy
 m2=0..n
 m1=1</panel_attributes>
     <additional_attributes>220.0;20.0;10.0;20.0</additional_attributes>
+  </element>
+  <element>
+    <id>UMLNote</id>
+    <coordinates>
+      <x>406</x>
+      <y>196</y>
+      <w>147</w>
+      <h>84</h>
+    </coordinates>
+    <panel_attributes>La marca (mark) en cada 
+CodeAudit será el resultado
+de hacer la moda de las marcas
+de los AuditRecors asociados.
+Los empates deben romper
+arbitrariamente si fuese 
+necesario.
+
+bg=blue</panel_attributes>
+    <additional_attributes/>
   </element>
 </diagram>

--- a/src/main/java/acme/entities/audits/CodeAudit.java
+++ b/src/main/java/acme/entities/audits/CodeAudit.java
@@ -11,7 +11,7 @@ import javax.persistence.TemporalType;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.PastOrPresent;
+import javax.validation.constraints.Past;
 import javax.validation.constraints.Pattern;
 
 import org.hibernate.validator.constraints.Length;
@@ -37,7 +37,7 @@ public class CodeAudit extends AbstractEntity {
 
 	//execution date (in the past)
 	@Temporal(TemporalType.TIMESTAMP)
-	@PastOrPresent
+	@Past
 	@NotNull
 	private Date				execution;
 


### PR DESCRIPTION
Añadidas dos pequeñas correcciones desde mi rama personal. Dichas correcciones han sido: 

- Cambio de etiqueta @PastOrPresent a @Past en el atributo execution de la entidad CodeAudit.
- Añadida nota con la validación del atributo mark de CodeAudit en el UML.